### PR TITLE
feat(main): example upload/consume manifests

### DIFF
--- a/.github/workflows/spread.yaml
+++ b/.github/workflows/spread.yaml
@@ -75,3 +75,28 @@ jobs:
         run: |
           (cd _spread/cmd/spread && go build)
           _spread/cmd/spread/spread -v ${{ steps.spread-suites.outputs.run-tasks }}
+
+      - name: Upload manifests
+        if: ${{ steps.spread-suites.outputs.run-tasks }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifests_${{ matrix.runner.name }}
+          path: ~/manifests/**/*.wall
+          overwrite: true
+
+  consume-manifests:
+    needs: spread-tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download manifests
+        uses: actions/download-artifact@v4
+        with:
+          name: manifests_X64
+      - name: List manifests
+        run: |
+          echo "$PWD"
+          pwd
+          ls -lha .
+          ls -lha manifests
+          sudo apt update && sudo apt install --yes tree
+          tree manifests || true


### PR DESCRIPTION
# Proposed changes

Example of exporting manifests as a pipeline artifact and then consuming them.

## Related issues/PRs

- https://github.com/alesancor1/chisel-releases/pull/2
- https://github.com/alesancor1/chisel-releases/pull/3
- https://github.com/alesancor1/chisel-releases/pull/4
- https://github.com/alesancor1/chisel-releases/pull/5
- https://github.com/alesancor1/chisel-releases/pull/6

### Forward porting
n/a

## Checklist
* [x] I have read the [contributing guidelines](
https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md)
* [x] I have tested my changes ([see how](https://github.com/canonical/chisel-releases/blob/main/CONTRIBUTING.md#7-test-your-slices-before-opening-a-pr))
* [x] I have already submitted the [CLA form](
https://ubuntu.com/legal/contributors/agreement)